### PR TITLE
Update Service.php

### DIFF
--- a/src/Artisaninweb/SoapWrapper/Service.php
+++ b/src/Artisaninweb/SoapWrapper/Service.php
@@ -116,7 +116,7 @@ class Service {
      */
     public function call($function,$params)
     {
-        return call_user_func_array([$this->client, $function], $params);
+        return call_user_func_array([$this->client, $function], [$params]);
     }
 
     /**


### PR DESCRIPTION
SoapClient will drop the first parameter if you pass it in as a list of arguments. See: http://stackoverflow.com/questions/3812765/param0-disappearing-in-soap-request-in-php-using-soapclient-class

This bug was introduced here: https://github.com/artisaninweb/laravel-soap/commit/b2ff17cd006f6040f8b2bb0bc0bab272c2aa896f

Passing the parameters as a single array resolves the issue.
