### PR TITLE
Installation instructions for Laravel 5.2 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ Installation
 
 ## Laravel
 
+####Installation for Laravel 5.2 and above:
+
+Run `composer require artisaninweb/laravel-soap`
+
+Add the service provider in `app/config/app.php`.
+
+```php
+Artisaninweb\SoapWrapper\ServiceProvider::class, 
+```
+
+To use the alias, add this to the aliases in `app/config/app.php`.
+
+```php
+'SoapWrapper' => Artisaninweb\SoapWrapper\Facade\SoapWrapper::class,  
+```
+
+
+####Installation for Laravel 5.1 and below :
+
+
 Add `artisaninweb/laravel-soap` as requirement to composer.json
 
 ```javascript


### PR DESCRIPTION
Added setup instructions for Laravel 5.2 and up since :

1. 'Facades' is no longer present in `app/config/app.php` for these versions. Alias needs to be added instead.
2. `composer require artisaninweb/laravel-soap` is a cleaner way to include the package in the project instead of editing `composer.json` and then running a `composer install / composer update`