### PR TITLE
Added Laravel 5.5 support for Package Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Add `artisaninweb/laravel-soap` as requirement to composer.json
 }
 ```
 
+> If you're using Laravel 5.5 or higher you can skip the two config setups below.
+
 Add the service provider in `app/config/app.php`.
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,15 @@
         "psr-0": {
             "Artisaninweb\\SoapWrapper": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Artisaninweb\\SoapWrapper\\ServiceProvider"
+            ],
+            "aliases": {
+                "SoapWrapper": "Artisaninweb\\SoapWrapper\\Facade"
+            }
+        }
     }
 }


### PR DESCRIPTION
For more information look at the [documentation](https://laravel.com/docs/5.5/packages#package-discovery).  

In short: For people that use Laravel 5.5 or higher will never need to add your ServiceProvider or Facade to the config in there `app.php` config file.