### PR TITLE
Don't touch the classmap if it's associative

### DIFF
--- a/src/Artisaninweb/SoapWrapper/Service.php
+++ b/src/Artisaninweb/SoapWrapper/Service.php
@@ -173,12 +173,17 @@ class Service
    *
    * @return array
    */
-  public function getClassmap()
+  public function getClassMap()
   {
     $classmap = $this->classmap;
     $classes  = [] ;
 
     if (!empty($classmap)) {
+      if (array_keys($classmap) !== range(0, \count($classmap))) {
+          // If this is an associative array, don't touch it
+          return $classmap;
+      }
+
       foreach ($classmap as $class) {
         // Can't use end because of strict mode :(
         $name = current(array_slice(explode('\\', $class), -1, 1, true));
@@ -214,7 +219,7 @@ class Service
     $options = [
       'trace'      => $this->getTrace(),
       'cache_wsdl' => $this->getCache(),
-      'classmap'   => $this->getClassmap(),
+      'classmap'   => $this->getClassMap(),
     ];
 
     if ($this->certificate) {


### PR DESCRIPTION
As mentioned in issue #140, I just lost a lot of time assuming that an associative classmap would not be touched, but I was wrong. So here's a PR that skips modifying associative maps.

I've also changed the method name case to follow the setter name... `getClassMap` instead of `getClassmap` for consistency. 