### PR TITLE
Namespace mentioned to create alias for laravel 5.2 was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Artisaninweb\SoapWrapper\ServiceProvider::class,
 To use the alias, add this to the aliases in `app/config/app.php`.
 
 ```php
-'SoapWrapper' => Artisaninweb\SoapWrapper\Facade\SoapWrapper::class,  
+'SoapWrapper' => Artisaninweb\SoapWrapper\SoapWrapper::class,  
 ```
 
 


### PR DESCRIPTION
To use the alias, add this to the aliases in app/config/app.php.

`'SoapWrapper' => Artisaninweb\SoapWrapper\Facade\SoapWrapper::class,`

The above line have incorrect nampespace it soapWrapper is under `Artisaninweb\SoapWrapper\SoapWrapper::class, ` 
